### PR TITLE
Document and demo custom system boxes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@
 - **LogMonitor** ingests Python logging output and configured files, normalises entries, and keeps bounded buffers per source while offering helpers to attach extra loggers and expose a Flask handler.【F:con5013/core/log_monitor.py†L20-L200】
 - **TerminalEngine** registers built-in commands (status, routes, HTTP probes, Python evaluation), manages history, and provides extension points for custom or Crawl4AI-specific commands alongside safe execution utilities.【F:con5013/core/terminal_engine.py†L22-L312】
 - **APIScanner** walks the Flask URL map to document endpoints, build sample paths, and exercise them either through the app’s test client or outbound HTTP requests for comprehensive testing and reporting.【F:con5013/core/api_scanner.py†L20-L338】
-- **SystemMonitor** aggregates system, application, and (optionally) GPU metrics using `psutil`/`pynvml`, formats uptime, paginates processes, and derives overall health signals.【F:con5013/core/system_monitor.py†L18-L320】
+- **SystemMonitor** aggregates system, application, and (optionally) GPU metrics using `psutil`/`pynvml`, formats uptime, paginates processes, derives overall health signals, and merges any custom boxes registered through `Con5013.add_system_box` into the stats payload so UI extensions stay in lockstep with native metrics.【F:con5013/core/system_monitor.py†L18-L320】【F:con5013/__init__.py†L318-L449】
 - **Utility helpers** currently expose `get_con5013_instance` so request handlers can grab the active extension safely.【F:con5013/core/utils.py†L6-L16】
 
 ### Front-end assets

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,23 +46,26 @@ Treat commands like micro-APIs: validate input, return structured dictionaries, 
 ### Q12. Can I expose health data from external services in the System tab?
 Yes. Use the `system_monitor` hooks to register new collectors that fetch metrics from services like Redis, Elasticsearch, or Kubernetes. Return normalized dictionaries so they render alongside CPU/memory stats. For read-only dashboards, disable Terminal but keep these collectors active for a holistic operations view.
 
-### Q13. How do I integrate Crawl4AI telemetry if I already have bespoke scraping logic?
+### Q13. How do I add a custom card to the System tab?
+Call `console.add_system_box` after initializing Con5013. Provide a unique ID (or let the helper derive one from the title) plus a list of row dictionaries. Each row needs a `name` and `value`, and can optionally include a `progress` spec for inline gauges. For dynamic content, supply `callable` values or a `provider` function that returns the entire box payload. You can toggle visibility via `console.set_system_box_enabled` or remove it altogether with `console.remove_system_box`. The Matrix demo shows a static example, while the advanced implementation demonstrates dynamic provider-driven boxes.【F:examples/matrix_app.py†L74-L90】【F:examples/advanced_implementation.py†L128-L194】
+
+### Q14. How do I integrate Crawl4AI telemetry if I already have bespoke scraping logic?
 Enable `CON5013_CRAWL4AI_INTEGRATION` and attach your custom crawler loggers with aliases such as `crawl4ai-mybot`. Implement custom commands (e.g., `crawl status`, `crawl restart`) that call into your scraping orchestration layer. The API Scanner remains independent, so you can monitor REST endpoints and scraping jobs from the same console.
 
 ## Deployment & Operations
 
-### Q14. Does Con5013 work behind Gunicorn or uWSGI with multiple workers?
+### Q15. Does Con5013 work behind Gunicorn or uWSGI with multiple workers?
 Yes, but shared state matters. Use a centralized backend for terminal command execution queues and log storage if workers are stateless. For streaming features, enable sticky sessions or run the console on a single worker via a sidecar Flask process that proxies to your main app.
 
-### Q15. What should I consider when deploying behind a reverse proxy (Nginx, Traefik)?
+### Q16. What should I consider when deploying behind a reverse proxy (Nginx, Traefik)?
 Forward WebSocket traffic for the terminal endpoint, set proper `X-Forwarded-*` headers so system metrics report client info accurately, and, if SSL termination happens at the proxy, configure Flask’s `PREFERRED_URL_SCHEME` so generated links point to HTTPS.
 
-### Q16. Can I run Con5013 in environments without internet access?
+### Q17. Can I run Con5013 in environments without internet access?
 Absolutely. All static assets ship with the package, and the Matrix demo app runs offline. Make sure your virtual environment has the dependencies pre-installed, or build a wheel in a connected environment and transport it to the air-gapped network.
 
-### Q17. How do I integrate Con5013 in CI pipelines?
+### Q18. How do I integrate Con5013 in CI pipelines?
 Use the API endpoints to trigger self-tests. For instance, spin up a Flask app in your CI job, call `/con5013/api/system/health` to verify the extension loaded, and hit `/con5013/api/scanner/test-all` for route validation. You can also run pytest suites against the demo Matrix app as part of regression checks.
 
-### Q18. Is it possible to script console actions from external tools?
+### Q19. Is it possible to script console actions from external tools?
 Yes. Every tab corresponds to REST APIs documented under `/con5013/api`. Script actions using HTTP clients, or integrate with observability platforms by exporting logs, system metrics, or API test reports in JSON. Authentication is left to your Flask app, so reuse existing tokens or session cookies.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -14,6 +14,25 @@ Con5013 delivers a self-contained operations console for Flask applications. The
 - Optional GPU telemetry is gathered through NVIDIA NVML (`pynvml`) or an `nvidia-smi` fallback, enabling visibility into accelerator utilization when hardware is present.
 - Provides paginated process listings and aggregate health checks through `/api/system/stats`, `/api/system/health`, and `/api/system/processes` so operators can inspect load spikes or runaway workers without leaving the browser.
 
+### Custom System Boxes
+- Extend the System tab with domain-specific metrics using `console.add_system_box` or the `CON5013_SYSTEM_CUSTOM_BOXES` configuration hook. Static rows accept plain dictionaries, while callables and provider functions let you compute values on every refresh so the UI always reflects the latest state.
+
+```python
+console.add_system_box(
+    "cache-metrics",
+    title="Cache",
+    rows=[
+        {"name": "Hits", "value": "128,450"},
+        {
+            "name": "Hit Rate",
+            "value": "86%",
+            "progress": {"value": 86, "color_rules": [{"threshold": 70, "class": "warning"}]},
+        },
+    ],
+)
+```
+- Boxes can be toggled or removed at runtime, reordered with the `order` parameter, and enriched with descriptions or `progress` metadata for inline gauges. The example applications demonstrate both static Matrix-themed cards and advanced provider-driven panels.
+
 ## Developer Tooling
 
 ### API Discovery & Testing

--- a/examples/matrix_app.py
+++ b/examples/matrix_app.py
@@ -82,6 +82,18 @@ def create_app() -> Flask:
         'CON5013_DEFAULT_LOG_SOURCE': 'CON5013',
     })
 
+    # Showcase a custom System tab box with static Matrix lore
+    console.add_system_box(
+        'matrix-trilogy',
+        title='Matrix Trilogy',
+        description='Static data example rendered in the System tab.',
+        rows=[
+            {'name': 'The Matrix (1999)', 'value': 'Neo chooses the red pill'},
+            {'name': 'Reloaded (2003)', 'value': 'Burly brawl stress tests the One'},
+            {'name': 'Revolutions (2003)', 'value': 'Peace brokered with the Machines'},
+        ],
+    )
+
     # Register the demo custom command with help text from docstring
     console.add_custom_command('matrix', matrix_command, description=matrix_command.__doc__.split('\n')[0])
 


### PR DESCRIPTION
## Summary
- add a Matrix-themed custom box to the system tab in the matrix demo app
- wire advanced static and provider-driven system boxes into the comprehensive example
- document how to register custom system boxes across the feature guide, architecture overview, and FAQ

## Testing
- PYTHONPATH=examples python -m pytest tests

------
https://chatgpt.com/codex/tasks/task_e_68c9b8021844832593ad589c1d31a91b