### PR TITLE
Support custom console prefixes in advanced demo

### DIFF
--- a/con5013/templates/console.html
+++ b/con5013/templates/console.html
@@ -178,19 +178,27 @@
             The interface will load automatically once the runtime is ready.  
             You can also open it anytime with the shortcut shown below, on any page where the script is active.  
             <br><br>
+            {% set script_src = url_for('con5013.static', filename='js/con5013.js') %}
             <pre>
-&lt;script src="/con5013/static/js/con5013.js"&gt;&lt;/script&gt;
+&lt;script src="{{ script_src }}"&gt;&lt;/script&gt;
             </pre>
         </p>
         <div class="loading-indicator" aria-live="polite">
             <span aria-hidden="true"></span>
-            <strong>Press Alt + C</strong> to launch the console
+            <strong>Press {{ config.get('CON5013_HOTKEY', 'Alt + C') }}</strong> to launch the console
         </div>
         <noscript>
             JavaScript is required to run the CON5013 console.  
             Please enable JavaScript in your browser to continue.
         </noscript>
     </main>
-    <script src="/con5013/static/js/con5013.js"></script>
+    <script>
+        window.CON5013_BOOTSTRAP = {{ config | tojson }};
+    </script>
+    <script
+        src="{{ script_src }}"
+        data-con5013-base="{{ config.get('CON5013_URL_PREFIX', '/con5013') }}"
+        data-con5013-hotkey="{{ config.get('CON5013_HOTKEY', 'Alt+C') }}"
+    ></script>
 </body>
 </html>

--- a/examples/advanced_implementation.py
+++ b/examples/advanced_implementation.py
@@ -107,6 +107,18 @@ def configure_logging(app: Flask) -> None:
     app.logger.addHandler(stream_handler)
     app.logger.setLevel(logging.INFO)
 
+    # Ensure Werkzeug retains a console handler so Flask's startup banner is
+    # still emitted.  The default handler is replaced when we configure the
+    # application logger above, which otherwise suppresses the "Running on"
+    # message and makes the server appear to hang.
+    werkzeug_logger = logging.getLogger("werkzeug")
+    if not any(isinstance(handler, logging.StreamHandler) for handler in werkzeug_logger.handlers):
+        werkzeug_handler = logging.StreamHandler()
+        werkzeug_handler.setFormatter(fmt)
+        werkzeug_handler.setLevel(logging.INFO)
+        werkzeug_logger.addHandler(werkzeug_handler)
+    werkzeug_logger.setLevel(logging.INFO)
+
     for name, path in LOG_FILES.items():
         handler = RotatingFileHandler(path, maxBytes=1_000_000, backupCount=3)
         handler.setFormatter(fmt)

--- a/examples/matrix_app.py
+++ b/examples/matrix_app.py
@@ -136,25 +136,28 @@ def create_app() -> Flask:
                             <li>Ship: Nebuchadnezzar</li>
                         </ul>
                     </div>
-                    <div class="col card">
-                        <h3>Quick Links</h3>
-                        <ul>
-                            <li><a href="/con5013/">Open Con5013 Console</a></li>
-                            <li><a href="/con5013/api/info">Console Info API</a></li>
-                            <li><a href="/con5013/api/system/health">System Health</a></li>
-                            <li><a href="/con5013/api/logs?source=matrix">Logs: matrix file</a></li>
-                            <li><a href="/con5013/api/logs?source=flask">Logs: flask stream</a></li>
-                        </ul>
-                    </div>
+                <div class="col card">
+                    <h3>Quick Links</h3>
+                    <ul>
+                        <li><a href="{{ url_for('con5013.console_home') }}">Open Con5013 Console</a></li>
+                        <li><a href="{{ url_for('con5013.api_info') }}">Console Info API</a></li>
+                        <li><a href="{{ url_for('con5013.api_system_health') }}">System Health</a></li>
+                        <li><a href="{{ url_for('con5013.api_logs', source='matrix') }}">Logs: matrix file</a></li>
+                        <li><a href="{{ url_for('con5013.api_logs', source='flask') }}">Logs: flask stream</a></li>
+                    </ul>
                 </div>
-                <p class="muted">Press <strong>Alt + C</strong> to toggle the overlay (if enabled).</p>
             </div>
-            <!-- Con5013 overlay launcher: include once to enable the floating button on this page -->
-            <script src="/con5013/static/js/con5013.js"></script>
+            <p class="muted">Press <strong>{{ hotkey }}</strong> to toggle the overlay (if enabled).</p>
+        </div>
+        <!-- Con5013 overlay launcher: include once to enable the floating button on this page -->
+        <script src="{{ url_for('con5013.static', filename='js/con5013.js') }}"></script>
         </body>
         </html>
         """
-        return render_template_string(html)
+        return render_template_string(
+            html,
+            hotkey=console.config.get('CON5013_HOTKEY', 'Alt + C'),
+        )
 
     @app.route('/generate-logs')
     def generate_logs():


### PR DESCRIPTION
## Summary
- normalize and auto-detect the console base URL and hotkey inside the frontend script so it talks to custom prefixes
- render the advanced console template assets with `url_for` and expose bootstrap metadata for the JavaScript loader
- update the Matrix example links and launcher script to use blueprint URLs and the configured hotkey

## Testing
- PYTHONPATH=examples:. pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c1158a448325802eed8504d189c0