### PR TITLE
Clarify Crawl4AI Playwright setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,13 @@ You can install Con5013 from PyPI for the latest stable release or directly from
 ```bash
 # Latest stable release from PyPI
 pip install con5013
+
+# Enable Crawl4AI integration and its browser runtime
+pip install "con5013[crawl4ai]"
+python -m playwright install  # downloads the Chromium binary used by Crawl4AI
+
+# If the command above fails, ensure Playwright is installed first:
+# pip install playwright
 ```
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,9 +23,17 @@ pip install con5013
 ```bash
 # Enable Crawl4AI enhancements
 pip install "con5013[crawl4ai]"
+python -m playwright install  # download required browser binaries
 
 # Install all optional realtime dependencies
 pip install "con5013[full]"
+```
+
+If `python -m playwright install` reports that the module is missing, install Playwright first:
+
+```bash
+pip install playwright
+python -m playwright install
 ```
 
 ### Install from source

--- a/examples/crawl4ai_integration.py
+++ b/examples/crawl4ai_integration.py
@@ -5,6 +5,7 @@ import asyncio
 import contextlib
 import logging
 import random
+import sys
 import threading
 import time
 from collections import deque
@@ -616,9 +617,17 @@ if console.terminal_engine:
                 root_cause = exc.__cause__ or exc
                 if exc.args and exc.args[0] == "__crawler_init__":
                     logger.exception("Failed to initialize AsyncWebCrawler", exc_info=root_cause)
+                    python_cmd = (
+                        f"{sys.executable} -m playwright install"
+                        if sys.executable
+                        else "python -m playwright install"
+                    )
                     lines = messages + [
-                        "Unable to initialize Crawl4AI AsyncWebCrawler."
-                        " Try installing optional browser dependencies.",
+                        "Unable to initialize Crawl4AI AsyncWebCrawler.",
+                        " Optional browser dependencies appear to be missing.",
+                        " Install the Playwright browsers by running:",
+                        f"   {python_cmd}",
+                        " If the command is not available, install Playwright first with `pip install playwright`.",
                         f"Error: {root_cause}",
                     ]
                 else:
@@ -638,9 +647,17 @@ if console.terminal_engine:
                 crawler = WebCrawler(always_by_pass_cache=True, verbose=False)
             except Exception as exc:  # pragma: no cover - optional dependency path
                 logger.exception("Failed to initialize WebCrawler", exc_info=exc)
+                python_cmd = (
+                    f"{sys.executable} -m playwright install"
+                    if sys.executable
+                    else "python -m playwright install"
+                )
                 lines = messages + [
-                    "Unable to initialize Crawl4AI WebCrawler."
-                    " Try installing optional browser dependencies.",
+                    "Unable to initialize Crawl4AI WebCrawler.",
+                    " Optional browser dependencies appear to be missing.",
+                    " Install the Playwright browsers by running:",
+                    f"   {python_cmd}",
+                    " If the command is not available, install Playwright first with `pip install playwright`.",
                     f"Error: {exc}",
                 ]
                 return {"output": "\n".join(filter(None, lines)), "type": "text"}


### PR DESCRIPTION
## Summary
- provide explicit Playwright installation guidance when Crawl4AI fails to start
- document the required `python -m playwright install` step in the README and installation guide

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'matrix_app')*


------
https://chatgpt.com/codex/tasks/task_e_68ca0245758c832587d8fbb657f07848