### PR TITLE
Expose Con5013 console instance globally

### DIFF
--- a/con5013/static/js/con5013.js
+++ b/con5013/static/js/con5013.js
@@ -1953,6 +1953,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const options = { ...derived, ...explicit };
     con5013 = new Con5013Console(options);
+
+    try {
+        if (typeof window !== 'undefined') {
+            window.con5013 = con5013;
+            // Backwards compatibility shim for legacy integrations
+            if (!window.con5013Overlay) {
+                window.con5013Overlay = con5013;
+            }
+            window.Con5013Console = Con5013Console;
+        }
+    } catch (err) {
+        console.warn('Con5013: unable to expose console globally', err);
+    }
 });
 
 // Export for module systems


### PR DESCRIPTION
## Summary
- expose the initialized Con5013 console on the window so integration scripts can access its API
- provide a legacy window.con5013Overlay reference and export the constructor for compatibility with existing hooks

## Testing
- pytest *(fails: environment lacks importable con5013 package and matrix_app module)*

------
https://chatgpt.com/codex/tasks/task_e_68cace8afa1c8325a4535e373ec1de0c