### PR TITLE
Fix theme preview rendering in example app

### DIFF
--- a/examples/example_app.py
+++ b/examples/example_app.py
@@ -591,7 +591,8 @@ LANDING_TEMPLATE = """
             if (!preview) return;
             const preset = themePresets[presetName] || {};
             const lines = Object.entries(preset).map(([key, value]) => `${key}: ${value};`);
-            preview.textContent = `:root\n${lines.map(line => `  ${line}`).join('\n')}`;
+            const formatted = [':root', ...lines.map((line) => '  ' + line)].join('\n');
+            preview.textContent = formatted;
         }
 
         function applyTheme(presetName) {


### PR DESCRIPTION
## Summary
- adjust the theme preview rendering logic in the example app to avoid nested template literals that caused a syntax error in the browser

## Testing
- python -m compileall examples/example_app.py

------
https://chatgpt.com/codex/tasks/task_e_68cb1f7f98e08325a04f5cf19cade2ac