### PR TITLE
Improve module and metric toggles

### DIFF
--- a/con5013/static/css/con5013.css
+++ b/con5013/static/css/con5013.css
@@ -14,6 +14,10 @@
     --con5013-text-muted: #9ca3af;
 }
 
+.con5013-hidden {
+    display: none !important;
+}
+
 /* Console Overlay */
 .con5013-overlay {
     position: fixed;

--- a/examples/example_app.py
+++ b/examples/example_app.py
@@ -508,6 +508,7 @@ LANDING_TEMPLATE = """
                     <h3>System metrics focus</h3>
                     <p>Toggle individual cards to curate your operational dashboard.</p>
                     <label class="toggle"><span>System info</span><input type="checkbox" data-metric-toggle="system_info" checked></label>
+                    <label class="toggle"><span>Application</span><input type="checkbox" data-metric-toggle="application" checked></label>
                     <label class="toggle"><span>CPU</span><input type="checkbox" data-metric-toggle="cpu" checked></label>
                     <label class="toggle"><span>Memory</span><input type="checkbox" data-metric-toggle="memory" checked></label>
                     <label class="toggle"><span>Disk</span><input type="checkbox" data-metric-toggle="disk" checked></label>


### PR DESCRIPTION
## Summary
- add a System metrics focus toggle for the Application card on the landing page
- hide console tabs and system cards via a reusable helper class instead of removing them, so module toggles can re-enable features
- harden tab switching logic to fall back gracefully when features are disabled

## Testing
- PYTHONPATH=examples pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb308c72c8832595a30da9fbfe1b08