### PR TITLE
Improve terminal input layout

### DIFF
--- a/con5013/static/css/con5013.css
+++ b/con5013/static/css/con5013.css
@@ -256,32 +256,51 @@
 }
 
 /* Terminal Section */
+
 .con5013-terminal {
     background: var(--con5013-darker);
     border: 1px solid var(--con5013-border);
-    border-radius: 8px;
+    border-radius: 12px;
     padding: 16px;
     font-family: 'Courier New', monospace;
     font-size: 13px;
-    /* Let terminal grow with content; rely on outer tab scroll */
-    /* height: 400px; */
     display: flex;
     flex-direction: column;
+    position: relative;
+    --con5013-terminal-input-height: 72px;
+    --con5013-terminal-input-gap: 18px;
 }
 
 .con5013-terminal-output {
     flex: 1;
-    /* Avoid inner scroll; allow content to expand */
-    overflow-y: visible;
-    margin-bottom: 16px;
+    overflow-y: auto;
+    margin-bottom: 0;
     color: var(--con5013-text);
     line-height: 1.4;
+    padding-right: 4px;
+    scroll-behavior: smooth;
+    padding-bottom: calc(var(--con5013-terminal-input-height) + var(--con5013-terminal-input-gap));
 }
 
 .con5013-terminal-input {
+    position: sticky;
+    bottom: 0;
+    margin-top: var(--con5013-terminal-input-gap);
+    padding: 12px 16px;
     display: flex;
     align-items: flex-start; /* keep prompt aligned to the top line */
     gap: 8px;
+    background: rgba(15, 23, 42, 0.92);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(18px);
+    z-index: 5;
+}
+
+.con5013-terminal-input:focus-within {
+    border-color: rgba(16, 185, 129, 0.65);
+    box-shadow: 0 24px 55px rgba(16, 185, 129, 0.25);
 }
 
 .con5013-terminal-prompt {

--- a/con5013/static/js/con5013.js
+++ b/con5013/static/js/con5013.js
@@ -587,6 +587,7 @@ class Con5013Console {
                 const minPx = Math.ceil(lh + pad);
                 const desired = Math.max(minPx, Math.min(terminalInput.scrollHeight, maxPx));
                 terminalInput.style.height = desired + 'px';
+                this.updateTerminalInputMetrics();
             };
             terminalInput.addEventListener('input', autoResize);
             // Initialize height
@@ -613,6 +614,8 @@ class Con5013Console {
                 }
             });
         }
+
+        window.addEventListener('resize', () => this.updateTerminalInputMetrics());
         
         // Logs scroll pause/resume
         const logsContainer = document.getElementById('con5013-logs');
@@ -972,6 +975,7 @@ class Con5013Console {
         if (targetTab === 'terminal') {
             setTimeout(() => {
                 document.getElementById('con5013-terminal-command')?.focus();
+                this.updateTerminalInputMetrics();
             }, 100);
         } else if (targetTab === 'system') {
             this.refreshSystemStats();
@@ -1146,9 +1150,10 @@ class Con5013Console {
         const inputEl = document.getElementById('con5013-terminal-command');
         if (inputEl) {
             inputEl.style.height = 'auto';
+            this.updateTerminalInputMetrics();
         }
     }
-    
+
     addTerminalOutput(text, type = 'text') {
         const output = document.getElementById('con5013-terminal-output');
         if (!output) return;
@@ -1194,6 +1199,19 @@ class Con5013Console {
 
         output.appendChild(block);
         output.scrollTop = output.scrollHeight;
+    }
+
+    updateTerminalInputMetrics() {
+        const containers = document.querySelectorAll('.con5013-terminal');
+        containers.forEach((container) => {
+            const inputWrapper = container.querySelector('.con5013-terminal-input');
+            if (!inputWrapper || inputWrapper.offsetParent === null) return;
+            const styles = window.getComputedStyle(inputWrapper);
+            const marginTop = parseFloat(styles.marginTop) || 0;
+            const marginBottom = parseFloat(styles.marginBottom) || 0;
+            const total = inputWrapper.offsetHeight + marginTop + marginBottom;
+            container.style.setProperty('--con5013-terminal-input-height', `${Math.ceil(total)}px`);
+        });
     }
 
     // Determine content format using simple hints

--- a/con5013/templates/overlay.html
+++ b/con5013/templates/overlay.html
@@ -154,22 +154,41 @@
         }
         
         /* Terminal styles */
-        .terminal-output {
+        #terminal-panel {
+            display: flex;
+            flex-direction: column;
+            gap: 0;
+            --terminal-input-height: 70px;
+            --terminal-input-gap: 16px;
+        }
+
+        #terminal-panel .terminal-output {
             background: #000;
             color: #00ff00;
             padding: 15px;
-            border-radius: 5px;
+            border-radius: 8px;
             font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
             font-size: 14px;
-            height: 300px;
+            min-height: 300px;
             overflow-y: auto;
-            margin-bottom: 10px;
             border: 1px solid #333;
+            flex: 1;
+            padding-bottom: calc(var(--terminal-input-height) + var(--terminal-input-gap));
         }
-        
+
         .terminal-input {
             display: flex;
             gap: 10px;
+            align-items: flex-start;
+            position: sticky;
+            bottom: 0;
+            margin-top: var(--terminal-input-gap);
+            background: rgba(0, 0, 0, 0.9);
+            border: 1px solid rgba(0, 255, 0, 0.2);
+            border-radius: 10px;
+            padding: 12px 14px;
+            box-shadow: 0 18px 40px rgba(0, 0, 0, 0.6);
+            backdrop-filter: blur(12px);
         }
         
         .terminal-input input {


### PR DESCRIPTION
## Summary
- restyle the terminal panel so the command input floats above output with preserved spacing and glassmorphism feel
- update terminal scripting to recalculate input height for resizing, history navigation, and window resize events
- align the overlay terminal styles with the floating input treatment to keep layouts consistent

## Testing
- `PYTHONPATH=examples pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb393ce34483258a0a63526500a7a9