### PR TITLE
Add configurable authentication guard for Con5013

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,29 @@ Con5013(app, config={
 })
 ```
 
+### Authentication Options
+
+Protect the console and API routes by enabling built-in authentication modes. All checks are executed before every Con5013 request, returning JSON for API failures and a themed HTML error page for UI requests.
+
+```python
+Con5013(app, config={
+    'CON5013_AUTHENTICATION': 'basic',          # 'none' (default), 'basic', 'token', callable
+    'CON5013_AUTH_USER': 'operator',            # Required for basic auth
+    'CON5013_AUTH_PASSWORD': 's3cret',          # Required for basic auth
+    'CON5013_AUTH_TOKEN': 'super-secret',       # Required for token auth
+    'CON5013_AUTH_CALLBACK': verify_console_access,  # Optional fallback when using callables
+})
+```
+
+Supported modes:
+
+- **`False` / `'none'`** – default behaviour, all requests are allowed.
+- **`'basic'`** – HTTP Basic authentication using `CON5013_AUTH_USER` and `CON5013_AUTH_PASSWORD`.
+- **`'token'`** – expects `Authorization: Bearer <token>` (or `Token`/`X-Auth-Token`) matching `CON5013_AUTH_TOKEN`.
+- **Callable** – supply a callable for `CON5013_AUTHENTICATION` or set `CON5013_AUTH_CALLBACK`; it receives the Flask `request` and should return truthy/`None` to allow access. You can hook into Flask-Login, session checks, or any custom logic.
+
+If an authentication mode is enabled but its required configuration is missing, Con5013 returns an informative 500 response so misconfigurations are surfaced early.
+
 ### Log Sources
 
 Configure multiple log sources:

--- a/con5013/__init__.py
+++ b/con5013/__init__.py
@@ -128,6 +128,10 @@ class Con5013:
             'CON5013_CRAWL4AI_INTEGRATION': False,
             'CON5013_WEBSOCKET_SUPPORT': False,
             'CON5013_AUTHENTICATION': False,
+            'CON5013_AUTH_USER': None,
+            'CON5013_AUTH_PASSWORD': None,
+            'CON5013_AUTH_TOKEN': None,
+            'CON5013_AUTH_CALLBACK': None,
             
             # API scanner safety
             'CON5013_API_PROTECTED_ENDPOINTS': [

--- a/con5013/blueprint.py
+++ b/con5013/blueprint.py
@@ -6,6 +6,8 @@ Provides all the web routes and API endpoints for the Con5013 console.
 import json
 import time
 from flask import Blueprint, render_template, jsonify, request, current_app, abort
+
+from .core.security import enforce_con5013_security
 from .core.utils import get_con5013_instance
 
 # Create the blueprint
@@ -16,6 +18,14 @@ con5013_blueprint = Blueprint(
     static_folder='static',
     static_url_path='/static'
 )
+
+
+@con5013_blueprint.before_request
+def _enforce_security():
+    """Gate all Con5013 routes according to the configured auth policy."""
+    response = enforce_con5013_security()
+    if response is not None:
+        return response
 
 @con5013_blueprint.route('/')
 def console_home():

--- a/con5013/core/security.py
+++ b/con5013/core/security.py
@@ -1,0 +1,190 @@
+"""Security helpers for Con5013 protected endpoints."""
+
+from __future__ import annotations
+
+import base64
+import hmac
+import logging
+from typing import Any, Callable, Optional
+
+from flask import Response, current_app, jsonify, render_template, request
+from werkzeug.exceptions import Unauthorized
+from werkzeug.wrappers.response import Response as WerkzeugResponse
+
+logger = logging.getLogger(__name__)
+
+
+def _get_extension_config() -> Optional[dict[str, Any]]:
+    """Return the Con5013 configuration from the current Flask app."""
+    ext = getattr(current_app, "extensions", {}).get("con5013")
+    if ext is None:
+        logger.debug("Con5013 extension not registered on current app")
+        return None
+    return getattr(ext, "config", None)
+
+
+def _is_api_request(config: dict[str, Any]) -> bool:
+    endpoint = request.endpoint or ""
+    if endpoint.startswith("con5013."):
+        endpoint_name = endpoint.split(".", 1)[1]
+        if endpoint_name.startswith("api_"):
+            return True
+    url_prefix = config.get("CON5013_URL_PREFIX", "/con5013")
+    api_prefix = f"{url_prefix.rstrip('/')}/api"
+    full_path = request.path or ""
+    return full_path.startswith(api_prefix)
+
+
+def _json_response(message: str, status_code: int) -> Response:
+    return jsonify({"status": "error", "message": message}), status_code
+
+
+def _html_response(message: str, status_code: int) -> Response:
+    return render_template(
+        "auth_required.html",
+        status_code=status_code,
+        message=message,
+        request_path=request.path,
+    ), status_code
+
+
+def _unauthorized(
+    message: str,
+    *,
+    is_api: bool,
+    status_code: int = 401,
+    headers: Optional[dict[str, str]] = None,
+) -> Response:
+    response = _json_response(message, status_code) if is_api else _html_response(message, status_code)
+    if headers:
+        resp, code = response
+        for key, value in headers.items():
+            resp.headers[key] = value
+        return resp, code
+    return response
+
+
+def _get_basic_credentials() -> tuple[Optional[str], Optional[str]]:
+    auth = request.authorization
+    if auth is None and "Authorization" in request.headers:
+        try:
+            scheme, encoded = request.headers["Authorization"].split(" ", 1)
+        except ValueError:
+            return None, None
+        if scheme.lower() == "basic":
+            try:
+                decoded = base64.b64decode(encoded).decode("utf-8")
+            except Exception:
+                return None, None
+            if ":" not in decoded:
+                return None, None
+            username, password = decoded.split(":", 1)
+            return username, password
+        return None, None
+    if auth is None:
+        return None, None
+    return auth.username, auth.password
+
+
+def _extract_token() -> Optional[str]:
+    header = request.headers.get("Authorization", "")
+    if header.lower().startswith("bearer "):
+        return header[7:].strip()
+    if header.lower().startswith("token "):
+        return header[6:].strip()
+    return request.headers.get("X-Auth-Token")
+
+
+def _execute_callback(callback: Callable[[Any], Any], *, is_api: bool) -> Optional[Response]:
+    try:
+        result = callback(request)
+    except Unauthorized as exc:
+        logger.info("Con5013 auth callback raised Unauthorized: %s", exc)
+        return _unauthorized(str(exc), is_api=is_api)
+    except Exception:  # pragma: no cover - user callback can raise anything
+        logger.exception("Con5013 auth callback raised an unexpected error")
+        return _unauthorized("Authentication callback error", is_api=is_api, status_code=500)
+
+    if result is None or result is True:
+        return None
+    if result is False:
+        return _unauthorized("Access denied", is_api=is_api, status_code=403)
+    if isinstance(result, (Response, WerkzeugResponse)):
+        return result
+    if isinstance(result, tuple):
+        return current_app.make_response(result)
+    return current_app.make_response(result)
+
+
+def enforce_con5013_security() -> Optional[Response]:
+    """Validate access to the Con5013 blueprint based on configuration."""
+    config = _get_extension_config()
+    if not config:
+        return None
+
+    mode = config.get("CON5013_AUTHENTICATION")
+    if not mode:
+        return None
+    if isinstance(mode, str) and mode.lower() in {"none", "false"}:
+        return None
+
+    is_api = _is_api_request(config)
+
+    if callable(mode):
+        callback_response = _execute_callback(mode, is_api=is_api)
+        if callback_response is None:
+            return None
+        return callback_response
+
+    normalized = mode.lower() if isinstance(mode, str) else str(mode).lower()
+
+    if normalized == "basic":
+        expected_user = config.get("CON5013_AUTH_USER")
+        expected_password = config.get("CON5013_AUTH_PASSWORD")
+        if not expected_user or expected_password is None:
+            logger.warning("Basic authentication is enabled but credentials are not configured")
+            return _unauthorized(
+                "Authentication is not properly configured",
+                is_api=is_api,
+                status_code=500,
+            )
+        username, password = _get_basic_credentials()
+        if not username or not password:
+            return _unauthorized(
+                "Authentication required",
+                is_api=is_api,
+                headers={"WWW-Authenticate": 'Basic realm="Con5013"'},
+            )
+        if hmac.compare_digest(username, str(expected_user)) and hmac.compare_digest(password, str(expected_password)):
+            return None
+        return _unauthorized(
+            "Invalid credentials",
+            is_api=is_api,
+            headers={"WWW-Authenticate": 'Basic realm="Con5013"'},
+        )
+
+    if normalized == "token":
+        expected_token = config.get("CON5013_AUTH_TOKEN")
+        if expected_token is None:
+            logger.warning("Token authentication is enabled but no token is configured")
+            return _unauthorized(
+                "Authentication is not properly configured",
+                is_api=is_api,
+                status_code=500,
+            )
+        provided_token = _extract_token()
+        if not provided_token:
+            return _unauthorized("Missing token", is_api=is_api)
+        if hmac.compare_digest(str(provided_token), str(expected_token)):
+            return None
+        return _unauthorized("Invalid token", is_api=is_api)
+
+    callback = config.get("CON5013_AUTH_CALLBACK")
+    if callable(callback):
+        callback_response = _execute_callback(callback, is_api=is_api)
+        if callback_response is None:
+            return None
+        return callback_response
+
+    logger.warning("Unknown CON5013_AUTHENTICATION mode: %s", mode)
+    return _unauthorized("Access denied", is_api=is_api, status_code=403)

--- a/con5013/templates/auth_required.html
+++ b/con5013/templates/auth_required.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Con5013 Access Restricted</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        :root {
+            color-scheme: dark light;
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+        body {
+            margin: 0;
+            padding: 4rem 1.5rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: radial-gradient(circle at top, rgba(76, 110, 245, 0.15), transparent 55%),
+                        linear-gradient(160deg, rgba(28, 31, 53, 0.95), rgba(15, 15, 24, 0.9));
+            color: #f3f4f6;
+            min-height: 100vh;
+        }
+        .card {
+            max-width: 28rem;
+            background: rgba(24, 24, 36, 0.85);
+            border-radius: 20px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            box-shadow: 0 25px 45px rgba(15, 15, 24, 0.45);
+            backdrop-filter: blur(16px);
+            padding: 2.5rem;
+            text-align: center;
+        }
+        .card h1 {
+            margin: 0 0 0.75rem;
+            font-size: 1.75rem;
+            letter-spacing: 0.04em;
+        }
+        .card p {
+            margin: 0.25rem 0;
+            line-height: 1.6;
+            color: rgba(243, 244, 246, 0.85);
+        }
+        .card code {
+            display: inline-block;
+            padding: 0.2rem 0.45rem;
+            border-radius: 0.5rem;
+            background: rgba(76, 110, 245, 0.15);
+            color: #cbd5ff;
+            font-size: 0.85rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <h1>{{ status_code }} Access Restricted</h1>
+        <p>{{ message }}</p>
+        {% if request_path %}
+        <p>Requested path: <code>{{ request_path }}</code></p>
+        {% endif %}
+        <p>Please provide valid credentials or contact an administrator for access.</p>
+    </div>
+</body>
+</html>

--- a/examples/advanced_implementation.py
+++ b/examples/advanced_implementation.py
@@ -91,7 +91,10 @@ CON5013_CONFIG: Dict[str, Any] = {
     "CON5013_HOTKEY": "Alt+C",
     "CON5013_CRAWL4AI_INTEGRATION": False,
     "CON5013_WEBSOCKET_SUPPORT": False,
-    "CON5013_AUTHENTICATION": False,
+    # Lock down the console with HTTP Basic auth; swap to 'token' or a callback as needed.
+    "CON5013_AUTHENTICATION": "basic",
+    "CON5013_AUTH_USER": "operations",
+    "CON5013_AUTH_PASSWORD": "console-access",
 }
 
 


### PR DESCRIPTION
## Summary
- add a security helper that enforces basic, token, or callback authentication for Con5013 routes
- gate the blueprint with the helper and provide a themed unauthorized template
- document the new options and update the advanced example with basic auth defaults

## Testing
- PYTHONPATH=.:examples pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc86f549f4832586c3a964476861c7