### PR TITLE
Introduce security profiles for hardened deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,42 @@ Con5013(app, config={
 })
 ```
 
+### Security Profiles
+
+To simplify hardening the console for hosted environments, Con5013 now ships with
+`CON5013_SECURITY_PROFILE`. The default profile is `"open"`, which preserves the
+behaviour demonstrated throughout the README. Switching to `"secured"` disables
+high-impact features (terminal execution, API scanning, log clearing via
+`CON5013_ALLOW_LOG_CLEAR`, auto-injection, overlay mode, Crawl4AI hooks, web
+socket helpers, and Python evaluation) unless you explicitly override them.
+
+Pick a profile per environment during initialization:
+
+```python
+import os
+
+environment = os.getenv('FLASK_ENV', 'development')
+profile = 'secured' if environment == 'production' else 'open'
+
+console = Con5013(app, config={
+    'CON5013_SECURITY_PROFILE': profile,
+    # You can still provide explicit overrides alongside the profile
+    'CON5013_ENABLE_LOGS': True,
+})
+
+# Adjust at runtime if needed
+if profile == 'secured':
+    # Re-enable just the terminal for trusted operators
+    console.apply_security_profile('secured', extra_overrides={'CON5013_ENABLE_TERMINAL'})
+    console.config['CON5013_ENABLE_TERMINAL'] = True
+```
+
+The helper `console.apply_security_profile(...)` can also be called later if you
+need to harden or relax the console dynamically (for example, during an incident
+response window). Settings you tweak afterward remain in effect until you reapply
+the profile—pass `extra_overrides={'CON5013_ENABLE_TERMINAL', ...}` when calling
+the helper to mark them as preserved on subsequent invocations.
+
 ### Authentication Options
 
 Protect the console and API routes by enabling built-in authentication modes. All checks are executed before every Con5013 request, returning JSON for API failures and a themed HTML error page for UI requests.

--- a/con5013/blueprint.py
+++ b/con5013/blueprint.py
@@ -116,11 +116,12 @@ def api_log_sources():
 def api_clear_logs():
     """Clear logs for a specific source."""
     con5013 = get_con5013_instance()
-    if not con5013.config.get('CON5013_ENABLE_LOGS', True):
+    if not con5013.config.get('CON5013_ENABLE_LOGS', True) \
+            or not con5013.config.get('CON5013_ALLOW_LOG_CLEAR', True):
         abort(404)
     data = request.get_json() or {}
     source = data.get('source', 'app')
-    
+
     try:
         if con5013.log_monitor:
             con5013.log_monitor.clear_logs(source)
@@ -443,22 +444,24 @@ def api_info():
         'url_prefix': con5013.config['CON5013_URL_PREFIX'],
         'theme': con5013.config['CON5013_THEME'],
         'default_log_source': con5013.config.get('CON5013_DEFAULT_LOG_SOURCE'),
-            'features': {
-                'logs': con5013.config['CON5013_ENABLE_LOGS'],
-                'terminal': con5013.config['CON5013_ENABLE_TERMINAL'],
-                'api_scanner': con5013.config['CON5013_ENABLE_API_SCANNER'],
-                'system_monitor': con5013.config['CON5013_ENABLE_SYSTEM_MONITOR'],
-                'system_monitor_metrics': {
-                    'system_info': con5013.config.get('CON5013_MONITOR_SYSTEM_INFO', True),
-                    'application': con5013.config.get('CON5013_MONITOR_APPLICATION', True),
-                    'cpu': con5013.config.get('CON5013_MONITOR_CPU', True),
-                    'memory': con5013.config.get('CON5013_MONITOR_MEMORY', True),
-                    'disk': con5013.config.get('CON5013_MONITOR_DISK', True),
-                    'network': con5013.config.get('CON5013_MONITOR_NETWORK', True),
-                    'gpu': con5013.config.get('CON5013_MONITOR_GPU', True),
+        'features': {
+            'logs': con5013.config['CON5013_ENABLE_LOGS'],
+            'terminal': con5013.config['CON5013_ENABLE_TERMINAL'],
+            'api_scanner': con5013.config['CON5013_ENABLE_API_SCANNER'],
+            'system_monitor': con5013.config['CON5013_ENABLE_SYSTEM_MONITOR'],
+            'allow_log_clear': con5013.config.get('CON5013_ALLOW_LOG_CLEAR', True),
+            'system_monitor_metrics': {
+                'system_info': con5013.config.get('CON5013_MONITOR_SYSTEM_INFO', True),
+                'application': con5013.config.get('CON5013_MONITOR_APPLICATION', True),
+                'cpu': con5013.config.get('CON5013_MONITOR_CPU', True),
+                'memory': con5013.config.get('CON5013_MONITOR_MEMORY', True),
+                'disk': con5013.config.get('CON5013_MONITOR_DISK', True),
+                'network': con5013.config.get('CON5013_MONITOR_NETWORK', True),
+                'gpu': con5013.config.get('CON5013_MONITOR_GPU', True),
             },
-            'crawl4ai_integration': con5013.config['CON5013_CRAWL4AI_INTEGRATION'],
         },
+        'crawl4ai_integration': con5013.config['CON5013_CRAWL4AI_INTEGRATION'],
+        'security_profile': con5013.config.get('CON5013_SECURITY_PROFILE', 'open'),
         'endpoints': {
             'console': con5013.config['CON5013_URL_PREFIX'] + '/',
             'overlay': con5013.config['CON5013_URL_PREFIX'] + '/overlay',

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,6 +115,26 @@ app.config.update(
 Con5013(app)
 ```
 
+For a faster hardening pass, set `CON5013_SECURITY_PROFILE` to `"secured"`. The
+secured profile disables terminal execution, API scanning, log clearing
+(`CON5013_ALLOW_LOG_CLEAR`), auto-injection, overlay mode, Crawl4AI helpers, web
+socket hooks, and Python evaluation unless you explicitly override them.
+
+```python
+import os
+
+app = Flask(__name__)
+profile = 'secured' if os.getenv('FLASK_ENV') == 'production' else 'open'
+app.config['CON5013_SECURITY_PROFILE'] = profile
+
+console = Con5013(app)
+
+# Re-enable selected features after applying the profile if required
+if profile == 'secured':
+    console.apply_security_profile('secured', extra_overrides={'CON5013_ENABLE_TERMINAL'})
+    console.config['CON5013_ENABLE_TERMINAL'] = True
+```
+
 Refer to the defaults in `Con5013._get_default_config()` for the complete list of toggles, including API scanner, system monitor, Crawl4AI, and websocket options.
 
 ## Template and Overlay Integration

--- a/examples/example_app.py
+++ b/examples/example_app.py
@@ -209,6 +209,9 @@ def create_app() -> Flask:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
     app.logger.setLevel(logging.INFO)
 
+    environment = os.getenv("FLASK_ENV", "development")
+    security_profile = "secured" if environment == "production" else "open"
+
     console = Con5013(
         app,
         config={
@@ -220,8 +223,15 @@ def create_app() -> Flask:
             "CON5013_LOG_SOURCES": ["example_app.log"],
             "CON5013_MONITOR_GPU": True,
             "CON5013_SYSTEM_CUSTOM_BOXES": [],
+            "CON5013_SECURITY_PROFILE": security_profile,
         },
     )
+
+    if security_profile == "secured":
+        # Keep the interactive terminal available during demos while the
+        # profile hardens other features such as log clearing and auto-inject.
+        console.apply_security_profile("secured", extra_overrides={"CON5013_ENABLE_TERMINAL"})
+        console.config["CON5013_ENABLE_TERMINAL"] = True
 
     # Attach an additional logger so the Logs tab showcases multiple sources.
     worker_logger = logging.getLogger("demo.worker")


### PR DESCRIPTION
## Summary
- add security profile configuration with presets and an `apply_security_profile` helper
- lock down log clearing and surface profile/feature flags in the API and UI
- document per-environment profile selection and cover the workflow with examples and tests

## Testing
- PYTHONPATH=.:examples pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc8aec24608325b5ac47dda7c61960