### PR TITLE
Add external API guardrails to scanner

### DIFF
--- a/con5013/__init__.py
+++ b/con5013/__init__.py
@@ -62,6 +62,7 @@ class Con5013:
         'secured': {
             'CON5013_ENABLE_TERMINAL': False,
             'CON5013_ENABLE_API_SCANNER': False,
+            'CON5013_API_ALLOW_EXTERNAL': False,
             'CON5013_ALLOW_LOG_CLEAR': False,
             'CON5013_AUTO_INJECT': False,
             'CON5013_OVERLAY_MODE': False,
@@ -127,7 +128,9 @@ class Con5013:
             'CON5013_API_TEST_TIMEOUT': 10,
             'CON5013_API_INCLUDE_METHODS': ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
             'CON5013_API_EXCLUDE_ENDPOINTS': ['/static', '/con5013'],
-            
+            'CON5013_API_ALLOW_EXTERNAL': True,
+            'CON5013_API_EXTERNAL_ALLOWLIST': [],
+
             # System monitoring
             'CON5013_SYSTEM_UPDATE_INTERVAL': 5,
             'CON5013_MONITOR_SYSTEM_INFO': True,

--- a/con5013/blueprint.py
+++ b/con5013/blueprint.py
@@ -7,6 +7,7 @@ import json
 import time
 from flask import Blueprint, render_template, jsonify, request, current_app, abort
 
+from .core.api_scanner import APIScanner
 from .core.security import enforce_con5013_security
 from .core.utils import get_con5013_instance
 
@@ -462,6 +463,7 @@ def api_info():
         },
         'crawl4ai_integration': con5013.config['CON5013_CRAWL4AI_INTEGRATION'],
         'security_profile': con5013.config.get('CON5013_SECURITY_PROFILE', 'open'),
+        'scanner_policy': APIScanner.describe_policy_from_config(con5013.config),
         'endpoints': {
             'console': con5013.config['CON5013_URL_PREFIX'] + '/',
             'overlay': con5013.config['CON5013_URL_PREFIX'] + '/overlay',


### PR DESCRIPTION
## Summary
- add configurable CON5013_API_ALLOW_EXTERNAL flag (with secured profile defaulting to false) and normalize allowlist settings
- update the API scanner to block outbound probes when disabled or outside the allowlist and expose the policy via /api/info
- extend the test suite to cover the new policy handling and info endpoint reporting

## Testing
- PYTHONPATH=.:$(pwd)/examples pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc8e96e3bc83259a310f08cb70312b