### PR TITLE
Fix simulated console preview permissions

### DIFF
--- a/examples/secure_production_app.py
+++ b/examples/secure_production_app.py
@@ -74,22 +74,22 @@ ROLE_LABELS = {
 SIMULATED_FEATURES = [
     {
         "name": "Log viewer",
-        "endpoint": "con5013.logs",
+        "endpoint": "con5013.api_logs",
         "description": "Inspect immutable application logs captured by the secured profile.",
     },
     {
         "name": "System monitor",
-        "endpoint": "con5013.system_monitor",
+        "endpoint": "con5013.api_system_stats",
         "description": "Review CPU, memory, and request counters without shelling into the host.",
     },
     {
         "name": "API scanner",
-        "endpoint": "api_scanner.index",
+        "endpoint": "con5013.api_scanner_discover",
         "description": "Enumerate Flask routes to understand which surfaces are exposed.",
     },
     {
         "name": "Interactive terminal",
-        "endpoint": "api_terminal.execute",
+        "endpoint": "con5013.api_terminal_execute",
         "description": "Break-glass capability for administrators when deeper debugging is required.",
     },
 ]
@@ -1157,7 +1157,7 @@ def register_routes(app: Flask) -> None:
                 {
                     "name": feature["name"],
                     "description": feature["description"],
-                    "allowed": feature["endpoint"] != "api_terminal.execute",
+                    "allowed": feature["endpoint"] != "con5013.api_terminal_execute",
                 }
                 for feature in SIMULATED_FEATURES
             ]


### PR DESCRIPTION
## Summary
- align the simulated feature endpoints in `secure_production_app.py` with the real Con5013 blueprint endpoints
- ensure the hands-on authentication sandbox correctly blocks the terminal preview for non-admin modes

## Testing
- PYTHONPATH=examples pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccaab58cb88325805169e18aa21a3d